### PR TITLE
Jul 95/feature/AuthPageCustomInput

### DIFF
--- a/components/auth/AuthForm/AuthForm.tsx
+++ b/components/auth/AuthForm/AuthForm.tsx
@@ -19,26 +19,10 @@ const AuthForm = () => {
   const activeForm = useMemo(() => {
     return (searchValue === "signup"
       ? (
-        <SignupForm
-          onSubmit={(e) => {
-            e.preventDefault();
-            // 1. data, setData useState 만들기
-            // 2. CustomInput에서 data를 이용하여 validation 확인
-            // 3.
-
-            // eslint-disable-next-line no-alert
-            alert("회원가입 완료");
-          }}
-        />
+        <SignupForm />
       )
       : (
-        <SigninForm
-          onSubmit={(e) => {
-            e.preventDefault();
-            // eslint-disable-next-line no-alert
-            alert("로그인 완료");
-          }}
-        />
+        <SigninForm />
       ));
   }, [searchValue]);
   useEffect(() => {

--- a/components/auth/AuthForm/AuthForm.tsx
+++ b/components/auth/AuthForm/AuthForm.tsx
@@ -22,6 +22,10 @@ const AuthForm = () => {
         <SignupForm
           onSubmit={(e) => {
             e.preventDefault();
+            // 1. data, setData useState 만들기
+            // 2. CustomInput에서 data를 이용하여 validation 확인
+            // 3.
+
             // eslint-disable-next-line no-alert
             alert("회원가입 완료");
           }}

--- a/components/auth/AuthForm/SigninForm.tsx
+++ b/components/auth/AuthForm/SigninForm.tsx
@@ -6,7 +6,11 @@ import styles from "./AuthForm.module.scss";
 
 const SigninForm = () => {
   const [rendering, setRendering] = useState(false);
-  const [buttonClickCount, setButtonClickCount] = useState(0);
+  const [countValidation, setCountValidation] = useState({
+    email: 0,
+    password: 0,
+  });
+
   const [data, setData] = useState({
     email: "",
     password: "",
@@ -29,7 +33,10 @@ const SigninForm = () => {
     // eslint-disable-next-line max-len, @typescript-eslint/no-unused-vars
     const checkPasswordValidation : boolean = inputValidation(ValidationTarget.PASSWORD, data.password);
     setRendering(!rendering);
-    setButtonClickCount((prev) => { return prev + 1; });
+    setCountValidation({
+      email: 1,
+      password: 1,
+    });
   };
 
   return (
@@ -45,7 +52,8 @@ const SigninForm = () => {
         onChange={handleData}
         data={data}
         rendering={rendering}
-        buttonClickCount={buttonClickCount}
+        countValidation={countValidation}
+        setCountValidation={setCountValidation}
       />
       <CustomInput
         element="text"
@@ -58,7 +66,8 @@ const SigninForm = () => {
         onChange={handleData}
         data={data}
         rendering={rendering}
-        buttonClickCount={buttonClickCount}
+        countValidation={countValidation}
+        setCountValidation={setCountValidation}
       />
       <input
         type="submit"

--- a/components/auth/AuthForm/SigninForm.tsx
+++ b/components/auth/AuthForm/SigninForm.tsx
@@ -1,17 +1,16 @@
 import { CustomInput } from "components/common";
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
 import inputValidation from "utils/inputValidation";
 import styles from "./AuthForm.module.scss";
 
 const SigninForm = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [rendering, setRendering] = useState(false);
+  const [buttonClickCount, setButtonClickCount] = useState(0);
   const [data, setData] = useState({
     email: "",
     password: "",
   });
-
-  const [click, setClick] = useState(false);
 
   const handleData = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setData((prev) => {
@@ -23,11 +22,14 @@ const SigninForm = () => {
   };
 
   // 함수가 실행되면 유효성 검사가 시작됨
-  const handleSubmit = (event: any) => {
+  const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    const checkEmailValidation = inputValidation(ValidationTarget.EMAIL, data.email);
-    const checkPasswordValidation = inputValidation(ValidationTarget.PASSWORD, data.password);
-    setClick(!click);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const checkEmailValidation: boolean = inputValidation(ValidationTarget.EMAIL, data.email);
+    // eslint-disable-next-line max-len, @typescript-eslint/no-unused-vars
+    const checkPasswordValidation : boolean = inputValidation(ValidationTarget.PASSWORD, data.password);
+    setRendering(!rendering);
+    setButtonClickCount((prev) => { return prev + 1; });
   };
 
   return (
@@ -42,6 +44,8 @@ const SigninForm = () => {
         validationTarget={ValidationTarget.EMAIL}
         onChange={handleData}
         data={data}
+        rendering={rendering}
+        buttonClickCount={buttonClickCount}
       />
       <CustomInput
         element="text"
@@ -53,6 +57,8 @@ const SigninForm = () => {
         validationTarget={ValidationTarget.PASSWORD}
         onChange={handleData}
         data={data}
+        rendering={rendering}
+        buttonClickCount={buttonClickCount}
       />
       <input
         type="submit"

--- a/components/auth/AuthForm/SigninForm.tsx
+++ b/components/auth/AuthForm/SigninForm.tsx
@@ -1,18 +1,17 @@
 import { CustomInput } from "components/common";
-import { FormEventHandler, useState } from "react";
+import { useState } from "react";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
+import inputValidation from "utils/inputValidation";
 import styles from "./AuthForm.module.scss";
 
-interface SigninFormProps {
-  onSubmit: FormEventHandler;
-}
-
-const SigninForm = ({ onSubmit }: SigninFormProps) => {
+const SigninForm = () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [data, setData] = useState({
     email: "",
     password: "",
   });
+
+  const [click, setClick] = useState(false);
 
   const handleData = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setData((prev) => {
@@ -23,10 +22,38 @@ const SigninForm = ({ onSubmit }: SigninFormProps) => {
     });
   };
 
+  // 함수가 실행되면 유효성 검사가 시작됨
+  const handleSubmit = (event: any) => {
+    event.preventDefault();
+    const checkEmailValidation = inputValidation(ValidationTarget.EMAIL, data.email);
+    const checkPasswordValidation = inputValidation(ValidationTarget.PASSWORD, data.password);
+    setClick(!click);
+  };
+
   return (
-    <form className={styles.form} onSubmit={onSubmit}>
-      <CustomInput element="text" type="text" label="이메일" placeholder="입력" id="email" name="email" validationTarget={ValidationTarget.EMAIL} onChange={handleData} data={data} />
-      <CustomInput element="text" type="password" label="비밀번호" placeholder="입력" id="password" name="password" validationTarget={ValidationTarget.PASSWORD} onChange={handleData} data={data} />
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <CustomInput
+        element="text"
+        type="text"
+        label="이메일"
+        placeholder="입력"
+        id="email"
+        name="email"
+        validationTarget={ValidationTarget.EMAIL}
+        onChange={handleData}
+        data={data}
+      />
+      <CustomInput
+        element="text"
+        type="password"
+        label="비밀번호"
+        placeholder="입력"
+        id="password"
+        name="password"
+        validationTarget={ValidationTarget.PASSWORD}
+        onChange={handleData}
+        data={data}
+      />
       <input
         type="submit"
         className={styles.submitButton}

--- a/components/auth/AuthForm/SigninForm.tsx
+++ b/components/auth/AuthForm/SigninForm.tsx
@@ -9,11 +9,13 @@ const SigninForm = () => {
   const [countValidation, setCountValidation] = useState({
     email: 0,
     password: 0,
+    password_confirm: 0,
   });
 
   const [data, setData] = useState({
     email: "",
     password: "",
+    password_confirm: "",
   });
 
   const handleData = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -25,7 +27,6 @@ const SigninForm = () => {
     });
   };
 
-  // 함수가 실행되면 유효성 검사가 시작됨
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,7 +37,11 @@ const SigninForm = () => {
     setCountValidation({
       email: 1,
       password: 1,
+      password_confirm: 1,
     });
+    // 이메일, 비밀번호 유효성 검사가 통과되면 실행되는 코드를 넣어주시면 됩니다.
+    // eslint-disable-next-line no-empty
+    if (checkEmailValidation && checkPasswordValidation) {}
   };
 
   return (

--- a/components/auth/AuthForm/SigninForm.tsx
+++ b/components/auth/AuthForm/SigninForm.tsx
@@ -1,4 +1,6 @@
-import { FormEventHandler } from "react";
+import { CustomInput } from "components/common";
+import { FormEventHandler, useState } from "react";
+import { ValidationTarget } from "types/enums/inputValidation.enum";
 import styles from "./AuthForm.module.scss";
 
 interface SigninFormProps {
@@ -6,16 +8,25 @@ interface SigninFormProps {
 }
 
 const SigninForm = ({ onSubmit }: SigninFormProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [data, setData] = useState({
+    email: "",
+    password: "",
+  });
+
+  const handleData = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setData((prev) => {
+      return {
+        ...prev,
+        [event.target.name]: event.target.value,
+      };
+    });
+  };
+
   return (
     <form className={styles.form} onSubmit={onSubmit}>
-      <div className={styles.inputContainer}>
-        <span>이메일</span>
-        <input type="text" placeholder="입력" />
-      </div>
-      <div className={styles.inputContainer}>
-        <span>비밀번호</span>
-        <input type="password" placeholder="입력" />
-      </div>
+      <CustomInput element="text" type="text" label="이메일" placeholder="입력" id="email" name="email" validationTarget={ValidationTarget.EMAIL} onChange={handleData} />
+      <CustomInput element="text" type="password" label="비밀번호" placeholder="입력" id="password" name="password" validationTarget={ValidationTarget.PASSWORD} onChange={handleData} />
       <input
         type="submit"
         className={styles.submitButton}

--- a/components/auth/AuthForm/SigninForm.tsx
+++ b/components/auth/AuthForm/SigninForm.tsx
@@ -25,8 +25,8 @@ const SigninForm = ({ onSubmit }: SigninFormProps) => {
 
   return (
     <form className={styles.form} onSubmit={onSubmit}>
-      <CustomInput element="text" type="text" label="이메일" placeholder="입력" id="email" name="email" validationTarget={ValidationTarget.EMAIL} onChange={handleData} />
-      <CustomInput element="text" type="password" label="비밀번호" placeholder="입력" id="password" name="password" validationTarget={ValidationTarget.PASSWORD} onChange={handleData} />
+      <CustomInput element="text" type="text" label="이메일" placeholder="입력" id="email" name="email" validationTarget={ValidationTarget.EMAIL} onChange={handleData} data={data} />
+      <CustomInput element="text" type="password" label="비밀번호" placeholder="입력" id="password" name="password" validationTarget={ValidationTarget.PASSWORD} onChange={handleData} data={data} />
       <input
         type="submit"
         className={styles.submitButton}

--- a/components/auth/AuthForm/SignupForm.tsx
+++ b/components/auth/AuthForm/SignupForm.tsx
@@ -1,15 +1,20 @@
-import React, { FormEventHandler, useState } from "react";
+import React, { useState } from "react";
 import { CustomInput } from "components/common";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
+import inputValidation from "utils/inputValidation";
 import UserTypeSelect from "./UserTypeSelect";
 import styles from "./AuthForm.module.scss";
 
-interface SignupFormProps {
-  onSubmit: FormEventHandler;
-}
+const SignupForm = () => {
+  const [rendering, setRendering] = useState(false);
+  const [countValidation, setCountValidation] = useState({
+    email: 0,
+    password: 0,
+    password_confirm: 0,
+  });
 
-const SignupForm = ({ onSubmit }: SignupFormProps) => {
   const [data, setData] = useState({
+    email: "",
     password: "",
     password_confirm: "",
   });
@@ -23,11 +28,67 @@ const SignupForm = ({ onSubmit }: SignupFormProps) => {
     });
   };
 
+  // 함수가 실행되면 유효성 검사가 시작됨
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const checkEmailValidation: boolean = inputValidation(ValidationTarget.EMAIL, data.email);
+    // eslint-disable-next-line max-len, @typescript-eslint/no-unused-vars
+    const checkPasswordValidation : boolean = inputValidation(ValidationTarget.PASSWORD, data.password);
+    setRendering(!rendering);
+    setCountValidation({
+      email: 1,
+      password: 1,
+      password_confirm: 1,
+    });
+    //
+    // eslint-disable-next-line no-empty
+    if (checkEmailValidation && checkPasswordValidation) {}
+  };
   return (
-    <form className={styles.form} onSubmit={onSubmit}>
-      <CustomInput element="text" type="text" label="이메일" placeholder="입력" id="email" name="email" validationTarget={ValidationTarget.EMAIL} onChange={handleData} />
-      <CustomInput element="text" type="password" label="비밀번호" placeholder="입력" id="password" name="password" validationTarget={ValidationTarget.PASSWORD} onChange={handleData} data={data} />
-      <CustomInput element="text" type="password" label="비밀번호 확인" placeholder="입력" id="password_confirm" name="password_confirm" validationTarget={ValidationTarget.PASSWORD_CONFIRM} onChange={handleData} data={data} />
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <CustomInput
+        element="text"
+        type="text"
+        label="이메일"
+        placeholder="입력"
+        id="email"
+        name="email"
+        validationTarget={ValidationTarget.EMAIL}
+        onChange={handleData}
+        data={data}
+        rendering={rendering}
+        countValidation={countValidation}
+        setCountValidation={setCountValidation}
+      />
+      <CustomInput
+        element="text"
+        type="password"
+        label="비밀번호"
+        placeholder="입력"
+        id="password"
+        name="password"
+        validationTarget={ValidationTarget.PASSWORD}
+        onChange={handleData}
+        data={data}
+        rendering={rendering}
+        countValidation={countValidation}
+        setCountValidation={setCountValidation}
+      />
+      <CustomInput
+        element="text"
+        type="password"
+        label="비밀번호 확인"
+        placeholder="입력"
+        id="password_confirm"
+        name="password_confirm"
+        validationTarget={ValidationTarget.PASSWORD_CONFIRM}
+        onChange={handleData}
+        data={data}
+        rendering={rendering}
+        countValidation={countValidation}
+        setCountValidation={setCountValidation}
+      />
       <UserTypeSelect onChange={() => {}} />
       <input
         type="submit"

--- a/components/auth/AuthForm/SignupForm.tsx
+++ b/components/auth/AuthForm/SignupForm.tsx
@@ -1,4 +1,6 @@
-import { FormEventHandler } from "react";
+import React, { FormEventHandler, useState } from "react";
+import { CustomInput } from "components/common";
+import { ValidationTarget } from "types/enums/inputValidation.enum";
 import UserTypeSelect from "./UserTypeSelect";
 import styles from "./AuthForm.module.scss";
 
@@ -7,20 +9,25 @@ interface SignupFormProps {
 }
 
 const SignupForm = ({ onSubmit }: SignupFormProps) => {
+  const [data, setData] = useState({
+    password: "",
+    password_confirm: "",
+  });
+
+  const handleData = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setData((prev) => {
+      return {
+        ...prev,
+        [event.target.name]: event.target.value,
+      };
+    });
+  };
+
   return (
     <form className={styles.form} onSubmit={onSubmit}>
-      <div className={styles.inputContainer}>
-        <span>이메일</span>
-        <input type="email" placeholder="입력" />
-      </div>
-      <div className={styles.inputContainer}>
-        <span>비밀번호</span>
-        <input type="password" placeholder="입력" />
-      </div>
-      <div className={styles.inputContainer}>
-        <span>비밀번호 확인</span>
-        <input type="password" placeholder="입력" />
-      </div>
+      <CustomInput element="text" type="text" label="이메일" placeholder="입력" id="email" name="email" validationTarget={ValidationTarget.EMAIL} onChange={handleData} />
+      <CustomInput element="text" type="password" label="비밀번호" placeholder="입력" id="password" name="password" validationTarget={ValidationTarget.PASSWORD} onChange={handleData} data={data} />
+      <CustomInput element="text" type="password" label="비밀번호 확인" placeholder="입력" id="password_confirm" name="password_confirm" validationTarget={ValidationTarget.PASSWORD_CONFIRM} onChange={handleData} data={data} />
       <UserTypeSelect onChange={() => {}} />
       <input
         type="submit"

--- a/components/common/CustomInput/CustomInput.module.scss
+++ b/components/common/CustomInput/CustomInput.module.scss
@@ -38,6 +38,14 @@
     }
   }
 
+  .show {
+    display: block;
+  }
+
+  .hide {
+    display: none;
+  }
+
   .swing {
     color: $red-40;
     animation: swing 0.3s ease;

--- a/components/common/CustomInput/CustomInput.module.scss
+++ b/components/common/CustomInput/CustomInput.module.scss
@@ -38,6 +38,16 @@
     }
   }
 
+  .swing {
+    color: $red-40;
+    animation: swing 0.3s ease;
+    margin: {
+      top: 0.8rem;
+      left: 0.8rem;
+      bottom: 0;
+    }
+  }
+
   .inputNumber {
     padding: {
       top: 1.6rem;
@@ -83,6 +93,21 @@
 }
 
 @keyframes shake {
+  0% {
+    transform: translate(0);
+  }
+  25% {
+    transform: translate(-0.3rem);
+  }
+  75% {
+    transform: translate(0.3rem);
+  }
+  100% {
+    transform: translate(0);
+  }
+}
+
+@keyframes swing {
   0% {
     transform: translate(0);
   }

--- a/components/common/CustomInput/CustomInput.module.scss
+++ b/components/common/CustomInput/CustomInput.module.scss
@@ -1,5 +1,6 @@
 .box {
   height: 11.6rem;
+  width: 100%;
 
   .label {
     display: block;

--- a/components/common/CustomInput/CustomInput.tsx
+++ b/components/common/CustomInput/CustomInput.tsx
@@ -32,12 +32,13 @@ const CustomInput = ({
 }: CustomInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { validation, validationContent, handleBlur } = useInputValidation(
+  const {
+    validation, validationContent, handleBlur, toggle,
+  } = useInputValidation(
     validationTarget as ValidationTarget,
     inputRef.current?.value as string,
     data as object,
   );
-
   return (
     <div className={styles.box}>
       <label className={styles.label} htmlFor={id}>{essential ? `${label}*` : label}</label>
@@ -51,7 +52,7 @@ const CustomInput = ({
         onBlur={handleBlur}
         onChange={onChange}
       />
-      {element === "text" && !validation && <p className={styles.validation}>{validationContent}</p>}
+      {element === "text" && !validation && <p className={toggle ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>}
     </div>
   );
 };

--- a/components/common/CustomInput/CustomInput.tsx
+++ b/components/common/CustomInput/CustomInput.tsx
@@ -7,8 +7,8 @@ import UserInput from "./UserInput";
 import styles from "./CustomInput.module.scss";
 
 interface IValidationType {
-  email: string,
-  password: string,
+  email?: string,
+  password?: string,
   password_confirm?: string
 }
 
@@ -20,8 +20,8 @@ interface CustomInputProps {
   id: string;
   name: string;
   onChange: (event:
-  React.ChangeEvent<HTMLInputElement> |
-  React.ChangeEvent<HTMLTextAreaElement>) => void;
+  React.ChangeEvent<HTMLInputElement |
+  HTMLTextAreaElement>) => void
   essential?: boolean;
   validationTarget?: ValidationTarget
   data?: IValidationType;

--- a/components/common/CustomInput/CustomInput.tsx
+++ b/components/common/CustomInput/CustomInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import useInputValidation from "hooks/useInputValidation";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
 import UserInput from "./UserInput";
@@ -28,17 +28,27 @@ interface CustomInputProps {
 }
 
 const CustomInput = ({
-  element, label, type, placeholder, essential, id, name, validationTarget, onChange, data,
+  element,
+  label,
+  type,
+  placeholder,
+  essential,
+  id,
+  name,
+  validationTarget,
+  onChange,
+  data,
 }: CustomInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const {
-    validation, validationContent, handleBlur, toggle,
+    validation, validationContent, handleBlur, toggle, setToggle,
   } = useInputValidation(
     validationTarget as ValidationTarget,
     inputRef.current?.value as string,
     data as object,
   );
+
   return (
     <div className={styles.box}>
       <label className={styles.label} htmlFor={id}>{essential ? `${label}*` : label}</label>
@@ -52,7 +62,7 @@ const CustomInput = ({
         onBlur={handleBlur}
         onChange={onChange}
       />
-      {element === "text" && !validation && <p className={toggle ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>}
+      {(element === "text" && !validation) && <p className={toggle ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>}
     </div>
   );
 };

--- a/components/common/CustomInput/CustomInput.tsx
+++ b/components/common/CustomInput/CustomInput.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import useInputValidation from "hooks/useInputValidation";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
+import useInputValidation from "hooks/useInputValidation";
 import UserInput from "./UserInput";
 import styles from "./CustomInput.module.scss";
 
@@ -10,6 +10,12 @@ interface IValidationType {
   email?: string,
   password?: string,
   password_confirm?: string
+}
+
+interface ICountValidation {
+  email: number;
+  password: number;
+  password_confirm: number
 }
 
 interface CustomInputProps {
@@ -26,8 +32,8 @@ interface CustomInputProps {
   validationTarget?: ValidationTarget
   data?: IValidationType;
   rendering?: boolean;
-  countValidation,
-  setCountValidation,
+  countValidation?: ICountValidation;
+  setCountValidation?: React.Dispatch<React.SetStateAction<ICountValidation>>;
 }
 
 const CustomInput = ({
@@ -53,7 +59,6 @@ const CustomInput = ({
     inputRef.current?.value as string,
     data as object,
     name,
-    countValidation,
     setCountValidation,
   );
 
@@ -63,8 +68,6 @@ const CustomInput = ({
     setChange(!change);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toggle, rendering]);
-
-  console.log(countValidation);
 
   return (
     <div className={styles.box}>
@@ -79,7 +82,9 @@ const CustomInput = ({
         onBlur={handleBlur}
         onChange={onChange}
       />
-      {element === "text" && (!!countValidation[name] && !validation) && <p className={change ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>}
+      {validationTarget && element === "text" && !!countValidation?.[name as keyof ICountValidation] && !validation && (
+      <p className={change ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>
+      )}
     </div>
   );
 };

--- a/components/common/CustomInput/CustomInput.tsx
+++ b/components/common/CustomInput/CustomInput.tsx
@@ -26,7 +26,8 @@ interface CustomInputProps {
   validationTarget?: ValidationTarget
   data?: IValidationType;
   rendering?: boolean;
-  buttonClickCount?: number
+  countValidation,
+  setCountValidation,
 }
 
 const CustomInput = ({
@@ -41,7 +42,8 @@ const CustomInput = ({
   onChange,
   data,
   rendering,
-  buttonClickCount,
+  countValidation,
+  setCountValidation,
 }: CustomInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const {
@@ -50,13 +52,19 @@ const CustomInput = ({
     validationTarget as ValidationTarget,
     inputRef.current?.value as string,
     data as object,
+    name,
+    countValidation,
+    setCountValidation,
   );
+
   const [change, setChange] = useState(false);
 
   useEffect(() => {
     setChange(!change);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toggle, rendering]);
+
+  console.log(countValidation);
 
   return (
     <div className={styles.box}>
@@ -71,7 +79,7 @@ const CustomInput = ({
         onBlur={handleBlur}
         onChange={onChange}
       />
-      {element === "text" && (!!buttonClickCount && !validation) && <p className={change ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>}
+      {element === "text" && (!!countValidation[name] && !validation) && <p className={change ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>}
     </div>
   );
 };

--- a/components/common/CustomInput/CustomInput.tsx
+++ b/components/common/CustomInput/CustomInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import useInputValidation from "hooks/useInputValidation";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
 import UserInput from "./UserInput";
@@ -25,6 +25,8 @@ interface CustomInputProps {
   essential?: boolean;
   validationTarget?: ValidationTarget
   data?: IValidationType;
+  rendering?: boolean;
+  buttonClickCount?: number
 }
 
 const CustomInput = ({
@@ -38,16 +40,23 @@ const CustomInput = ({
   validationTarget,
   onChange,
   data,
+  rendering,
+  buttonClickCount,
 }: CustomInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
-
   const {
-    validation, validationContent, handleBlur, toggle, setToggle,
+    validation, validationContent, handleBlur, toggle,
   } = useInputValidation(
     validationTarget as ValidationTarget,
     inputRef.current?.value as string,
     data as object,
   );
+  const [change, setChange] = useState(false);
+
+  useEffect(() => {
+    setChange(!change);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toggle, rendering]);
 
   return (
     <div className={styles.box}>
@@ -62,7 +71,7 @@ const CustomInput = ({
         onBlur={handleBlur}
         onChange={onChange}
       />
-      {(element === "text" && !validation) && <p className={toggle ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>}
+      {element === "text" && (!!buttonClickCount && !validation) && <p className={change ? `${styles.validation}` : `${styles.swing}`}>{validationContent}</p>}
     </div>
   );
 };

--- a/components/common/CustomInput/UserInput.tsx
+++ b/components/common/CustomInput/UserInput.tsx
@@ -12,8 +12,7 @@ interface UserInputProps {
   name: string;
   onBlur: React.FocusEventHandler<HTMLInputElement>;
   onChange :(event:
-  React.ChangeEvent<HTMLInputElement> |
-  React.ChangeEvent<HTMLTextAreaElement>) => void;
+  React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }
 
 const UserInput = ({

--- a/hooks/useInputValidation.ts
+++ b/hooks/useInputValidation.ts
@@ -20,17 +20,22 @@ const useInputValidation = (
   data?: object,
 ): { validation: boolean, validationContent: string, handleBlur: () => void } => {
   const [validation, setValidation] = useState<boolean>(true);
+  const [toggle, setToggle] = useState(false);
+
   const handleBlur = () => {
     if (validationTarget && !checkValidation(validationTarget, value, data)) {
       setValidation(false);
     } else {
       setValidation(true);
     }
+    setToggle(!toggle);
   };
 
   const validationContent: string = validationContentMap[validationTarget];
 
-  return { validation, validationContent, handleBlur };
+  return {
+    validation, validationContent, handleBlur, toggle,
+  };
 };
 
 export default useInputValidation;

--- a/hooks/useInputValidation.ts
+++ b/hooks/useInputValidation.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import checkValidation from "utils/inputValidation";
+import inputValidation from "utils/inputValidation";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
 
 const validationContentMap: {
@@ -18,12 +18,11 @@ const useInputValidation = (
   validationTarget: ValidationTarget,
   value: string,
   data?: object,
-): { validation: boolean, validationContent: string, handleBlur: () => void } => {
+): { validation: boolean, validationContent: string, handleBlur: () => void, toggle: boolean, setToggle: any } => {
   const [validation, setValidation] = useState<boolean>(true);
   const [toggle, setToggle] = useState(false);
-
-  const handleBlur = () => {
-    if (validationTarget && !checkValidation(validationTarget, value, data)) {
+  const handleBlur = (e) => {
+    if (validationTarget && !inputValidation(validationTarget, value, data)) {
       setValidation(false);
     } else {
       setValidation(true);
@@ -34,7 +33,7 @@ const useInputValidation = (
   const validationContent: string = validationContentMap[validationTarget];
 
   return {
-    validation, validationContent, handleBlur, toggle,
+    validation, validationContent, handleBlur, toggle, setToggle,
   };
 };
 

--- a/hooks/useInputValidation.ts
+++ b/hooks/useInputValidation.ts
@@ -20,7 +20,6 @@ const useInputValidation = (
   data?: object,
 ): { validation: boolean, validationContent: string, handleBlur: () => void } => {
   const [validation, setValidation] = useState<boolean>(true);
-
   const handleBlur = () => {
     if (validationTarget && !checkValidation(validationTarget, value, data)) {
       setValidation(false);

--- a/hooks/useInputValidation.ts
+++ b/hooks/useInputValidation.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import inputValidation from "utils/inputValidation";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
+import { preview } from "vite";
 
 const validationContentMap: {
   [key in ValidationTarget]: string
@@ -18,12 +19,22 @@ const useInputValidation = (
   validationTarget: ValidationTarget,
   value: string,
   data?: object,
-): { validation: boolean, validationContent: string, handleBlur: () => void, toggle: boolean } => {
+  name?: string,
+  countValidation?: any,
+  setCountValidation?: any,
+): { validation: boolean, validationContent: string, handleBlur: () => void, toggle: boolean, setButtonClickCount: any } => {
   const [validation, setValidation] = useState<boolean>(false);
   const [toggle, setToggle] = useState(false);
 
   const handleBlur = (e) => {
     e.preventDefault();
+    setCountValidation((prev) => {
+      return {
+        ...prev,
+        [name]: prev[name] + 1,
+      };
+    });
+
     if (validationTarget && !inputValidation(validationTarget, value, data)) {
       setValidation(false);
     } else {

--- a/hooks/useInputValidation.ts
+++ b/hooks/useInputValidation.ts
@@ -1,9 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import inputValidation from "utils/inputValidation";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
-import { preview } from "vite";
+
+interface ICountValidation {
+  email: number;
+  password: number;
+  password_confirm: number;
+}
 
 const validationContentMap: {
   [key in ValidationTarget]: string
@@ -20,20 +25,21 @@ const useInputValidation = (
   value: string,
   data?: object,
   name?: string,
-  countValidation?: any,
-  setCountValidation?: any,
-): { validation: boolean, validationContent: string, handleBlur: () => void, toggle: boolean, setButtonClickCount: any } => {
+  setCountValidation?:React.Dispatch<React.SetStateAction<ICountValidation>>,
+) => {
   const [validation, setValidation] = useState<boolean>(false);
   const [toggle, setToggle] = useState(false);
 
-  const handleBlur = (e) => {
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     e.preventDefault();
-    setCountValidation((prev) => {
-      return {
-        ...prev,
-        [name]: prev[name] + 1,
-      };
-    });
+    if (ValidationTarget && setCountValidation && name) {
+      setCountValidation((prev) => {
+        return {
+          ...prev,
+          [name as keyof ICountValidation]: prev[name as keyof ICountValidation] + 1,
+        };
+      });
+    }
 
     if (validationTarget && !inputValidation(validationTarget, value, data)) {
       setValidation(false);

--- a/hooks/useInputValidation.ts
+++ b/hooks/useInputValidation.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import inputValidation from "utils/inputValidation";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
 
@@ -18,10 +18,12 @@ const useInputValidation = (
   validationTarget: ValidationTarget,
   value: string,
   data?: object,
-): { validation: boolean, validationContent: string, handleBlur: () => void, toggle: boolean, setToggle: any } => {
-  const [validation, setValidation] = useState<boolean>(true);
+): { validation: boolean, validationContent: string, handleBlur: () => void, toggle: boolean } => {
+  const [validation, setValidation] = useState<boolean>(false);
   const [toggle, setToggle] = useState(false);
+
   const handleBlur = (e) => {
+    e.preventDefault();
     if (validationTarget && !inputValidation(validationTarget, value, data)) {
       setValidation(false);
     } else {
@@ -33,7 +35,7 @@ const useInputValidation = (
   const validationContent: string = validationContentMap[validationTarget];
 
   return {
-    validation, validationContent, handleBlur, toggle, setToggle,
+    validation, validationContent, handleBlur, toggle,
   };
 };
 

--- a/utils/inputValidation.ts
+++ b/utils/inputValidation.ts
@@ -12,7 +12,7 @@ const passwordRegexp = /^(?=.*[a-zA-Z가-힣!@#$%^&*()_+={}|[\]\\';:/?.,<>]).{8,
 // 전화번호 유효성 검사
 const telRegexp = /^01[016789]-\d{3,4}-\d{4}$/;
 
-const checkvalidation = (
+const inputValidation = (
   validationTarget: ValidationTarget,
   value: string,
   data?: DataType,
@@ -42,4 +42,4 @@ const checkvalidation = (
   }
 };
 
-export default checkvalidation;
+export default inputValidation;

--- a/utils/inputValidation.ts
+++ b/utils/inputValidation.ts
@@ -19,16 +19,15 @@ const checkvalidation = (
 ): boolean => {
   const tenDigits = (+value / 10) % 10;
   const oneDigits = +value % 10;
-
   if (!value) return false;
   switch (validationTarget) {
-    case ValidationTarget.EMAIL:
+    case "EMAIL":
       return emailRegexp.test(value.toString());
-    case ValidationTarget.PASSWORD:
+    case "PASSWORD":
       return passwordRegexp.test(value.toString());
-    case ValidationTarget.TEL:
+    case "TEL":
       return telRegexp.test(value.toString());
-    case ValidationTarget.HOURLY_PAY:
+    case "HOURLY_PAY":
       if (!oneDigits && !tenDigits) {
         return true;
       }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
1. 로그인 페이지와 회원가입 페이지에서 input 값이 비어있는 상태이고 버튼을 클릭하면 유효성 검사 메세지가 출력되지 않았던 오류를 해결헀습니다.
2. SignInForm과 SignupForm 컴포넌트에서 
```typescript
const [display, setDisplay] = useState(fales)
```
위 코드처럼 state를 boolean 값으로 처리할 경우 모든 input에 값이 적용되어 하나의 input에서 유효성 검사에 실패해도 다른 input의
유효성 검사 문구가 보여지는 오류를 해결했습니다.

## 기타 사항
현재 interface 타입으로 인하여 SignInForm 컴포넌트의 state 값에 password_confirm 프로퍼티 키 값이 있는데
로그인 할 경우 이 프로퍼티만 따로 빼서 객체를 생성한 뒤 사용하시면 될 것 같습니다 ㅠ..