### PR TITLE
JUL-96/스크롤 방향에 반응하는 네비게이션바 기능

### DIFF
--- a/app/kenny/page.tsx
+++ b/app/kenny/page.tsx
@@ -63,6 +63,12 @@ const Page = () => {
           </Popover>
         )}
       </div>
+      <div className={styles.formBackground}>
+        <AuthForm />
+      </div>
+      <div className={styles.formBackground}>
+        <AuthForm />
+      </div>
     </main>
   );
 };

--- a/components/common/GlobalNav/GlobalNav.module.scss
+++ b/components/common/GlobalNav/GlobalNav.module.scss
@@ -1,4 +1,12 @@
 .container {
+  background-color: $white;
+  position: sticky;
+  z-index: 10;
+  top: 0;
+  transition: top 0.3s, box-shadow 0.4s ease-out;
+}
+
+.contentContainer {
   display: flex;
   gap: 4rem;
   padding: 1.5rem 20.8rem;

--- a/components/common/GlobalNav/GlobalNav.tsx
+++ b/components/common/GlobalNav/GlobalNav.tsx
@@ -1,39 +1,47 @@
+"use client";
+
+import { useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { SearchBar } from "components/common";
+import useResponsiveHeader from "hooks/useResponsiveNavbar";
 import styles from "./GlobalNav.module.scss";
 
 const GlobalNav = () => {
+  const navRef = useRef(null);
+  useResponsiveHeader(navRef);
   return (
-    <nav className={styles.container}>
-      <div className={styles.leftItems}>
-        <Link href="/">
-          <div className={styles.logo}>
-            <Image
-              fill
-              src="/images/logo.svg"
-              alt="The Julge Logo"
-              priority
-            />
-          </div>
-        </Link>
-      </div>
-      <div className={styles.searchBar}>
-        <SearchBar
-          placeholder="가게 이름으로 찾아보세요"
-        />
-      </div>
-      <div className={styles.rightItems}>
-        <Link href="/auth?mode=signin">
-          <h2>
-            로그인
-          </h2>
-        </Link>
-        <Link href="/auth?mode=signup">
-          <h2>
-            회원가입
-          </h2>
-        </Link>
+    <nav ref={navRef} className={styles.container}>
+      <div className={styles.contentContainer}>
+        <div className={styles.leftItems}>
+          <Link href="/">
+            <div className={styles.logo}>
+              <Image
+                fill
+                src="/images/logo.svg"
+                alt="The Julge Logo"
+                priority
+              />
+            </div>
+          </Link>
+        </div>
+        <div className={styles.searchBar}>
+          <SearchBar
+            placeholder="가게 이름으로 찾아보세요"
+          />
+        </div>
+        <div className={styles.rightItems}>
+          <Link href="/auth?mode=signin">
+            <h2>
+              로그인
+            </h2>
+          </Link>
+          <Link href="/auth?mode=signup">
+            <h2>
+              회원가입
+            </h2>
+          </Link>
+        </div>
       </div>
     </nav>
   );

--- a/hooks/useResponsiveNavbar.ts
+++ b/hooks/useResponsiveNavbar.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect, useRef } from "react";
+
+const useResponsiveHeader = (headerRef: React.RefObject<HTMLElement>) => {
+  const prevScrollPositionRef = useRef(0);
+  const [currentScrollPosition, setCurrentScrollPosition] = useState(0);
+
+  const handleScroll = () => {
+    setCurrentScrollPosition(window.scrollY);
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (prevScrollPositionRef.current) {
+      if (currentScrollPosition > prevScrollPositionRef.current) {
+        headerRef.current?.classList.add("hide");
+        headerRef.current?.classList.remove("shadow");
+      } else {
+        headerRef.current?.classList.remove("hide");
+        headerRef.current?.classList.add("shadow");
+      }
+    }
+    if (currentScrollPosition === 0) {
+      headerRef.current?.classList.remove("hide");
+      headerRef.current?.classList.remove("shadow");
+    }
+    prevScrollPositionRef.current = currentScrollPosition;
+  }, [currentScrollPosition, headerRef]);
+};
+
+export default useResponsiveHeader;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -11,6 +11,17 @@ body {
   word-break: keep-all;
   font-size: 1.6rem;
 
+  nav.hide {
+    top: calc($navbar-height * (-1));
+    @include mobile {
+      top: calc($navbar-mobile-height * (-1));
+    }
+  }
+
+  nav.shadow {
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  }
+
   input {
     font-family: inherit;
     font-size: inherit;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -26,3 +26,7 @@ $green-10: #d4f7d4 !default;
 
 /* kaako */
 $kakao: #fee500 !default;
+
+/* navbar height */
+$navbar-height: 7rem !default;
+$navbar-mobile-height: 10.6rem !default;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
- GlobalNav컴포넌트를 `position: sticky`로 바꾸고, 대신 스크롤을 내릴 때 위 방향으로 사라지게 했습니다. 
- useResponsiveNavbar 커스텀 훅을 추가하여 사용자의 스크롤 방향 전환을 감지하여 방향 전환이 일어나면 nav엘리먼트에 특정 클래스를 부여하고 제외시키는 로직입니다. 

## 확인 방법
![반응형 네브바 테스트](https://github.com/LonelyIslet/TheJulge/assets/45449387/e697023b-77ff-4a5f-8704-bf3b309f6096)


## 기타 사항
- 스크롤에 매번 핸들러 함수가 호출되긴 하나 방향 전환만 판단하고, 리플로우와 리페인트는 방향 전환이 일어났을 시에만 시행하므로 따로 스로틀링을 적용하진 않았습니다. 스로틀링 또한 매 스크롤마다 타이머 조작이 들어가므로, 핸들러 함수의 방향 전환 판단 코드와 비교해봤을 때 큰 차이가 없을 것 같습니다. 
