### PR TITLE
JUL-108/Protected Route를 위한 HOC 추가 

### DIFF
--- a/app/my-profile/edit/page.tsx
+++ b/app/my-profile/edit/page.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { EditProfile } from "components/employee";
+import { withAuth, withUserType } from "components/hocs";
+import { UserType } from "types/enums/user.enum";
 import styles from "./page.module.scss";
 
 const MyProfilePage = () => {
@@ -17,4 +21,4 @@ const MyProfilePage = () => {
   );
 };
 
-export default MyProfilePage;
+export default withAuth(withUserType(MyProfilePage, UserType.EMPLOYEE));

--- a/app/my-profile/page.tsx
+++ b/app/my-profile/page.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { RegisteredMyProfile, ApplicationDetails } from "components/employee";
+import { withAuth, withUserType } from "components/hocs";
+import { UserType } from "types/enums/user.enum";
 import styles from "./page.module.scss";
 
 const MyProfilePage = () => {
@@ -15,4 +19,4 @@ const MyProfilePage = () => {
   );
 };
 
-export default MyProfilePage;
+export default withAuth(withUserType(MyProfilePage, UserType.EMPLOYEE));

--- a/app/my-shop/page.tsx
+++ b/app/my-shop/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   CommonLayout, ShopCard, NoticeCard, CommonBtn,
 } from "components/common";
@@ -5,6 +7,8 @@ import {
 import noticeData from "constants/mock/notice.json";
 // import noticeList from "constants/mock/noticeList.json";
 import styles from "@/page.module.scss";
+import { withAuth, withUserType } from "components/hocs";
+import { UserType } from "types/enums/user.enum";
 
 // interface INoticeWithClosedInfo extends INotice {
 //   id: string,
@@ -75,4 +79,4 @@ const MyShopPage = () => {
   );
 };
 
-export default MyShopPage;
+export default withAuth(withUserType(MyShopPage, UserType.EMPLOYER));

--- a/app/signout/page.tsx
+++ b/app/signout/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { withAuth } from "components/hocs";
+import useToast from "hooks/useToast";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import useAppDispatch from "redux/hooks/useAppDispatch";
+import { setUser } from "redux/slices/userSlice";
+
+const SignoutPage = () => {
+  const dispatch = useAppDispatch();
+  const [isLoggedOut, setIsLoggedOut] = useState(false);
+  const router = useRouter();
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    dispatch(setUser({ token: undefined, userInfo: undefined }));
+    setIsLoggedOut(true);
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (isLoggedOut) {
+      showToast("로그아웃 되었습니다.");
+      router.push("/");
+    }
+  }, [isLoggedOut, showToast, router]);
+
+  return null;
+};
+
+export default withAuth(SignoutPage);

--- a/components/common/CommonLayout/CommonLayout.module.scss
+++ b/components/common/CommonLayout/CommonLayout.module.scss
@@ -2,7 +2,7 @@
   max-width: 96.4rem;
   width: 100%;
   background-color: inherit;
-
+  overflow-x: clip;
   header.above {
     margin-bottom: 2.4rem;
   }

--- a/components/common/CommonLayout/CommonLayout.tsx
+++ b/components/common/CommonLayout/CommonLayout.tsx
@@ -18,7 +18,7 @@ const CommonLayout = ({
       <header className={headerStyle}>
         {title}
       </header>
-      <article draggable="true">
+      <article>
         {content}
       </article>
     </div>

--- a/components/common/GlobalNav/GlobalNav.module.scss
+++ b/components/common/GlobalNav/GlobalNav.module.scss
@@ -22,6 +22,7 @@
     flex-wrap: wrap;
     gap: 1.6rem;
     padding: 1rem 2rem;
+    width: 100%;
   }
 }
 

--- a/components/common/GlobalNav/GlobalNav.tsx
+++ b/components/common/GlobalNav/GlobalNav.tsx
@@ -4,16 +4,13 @@ import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { setUser } from "redux/slices/userSlice";
 import useAppSelector from "redux/hooks/useAppSelector";
-import useAppDispatch from "redux/hooks/useAppDispatch";
 import SearchBar from "components/common/SearchBar/SearchBar";
 import Popover from "components/common/Popover/Popover";
 import NotificationBoard from "components/common/NotificationBoard/NotificationBoard";
 import { IAlert } from "types/dto";
 import { UserType } from "types/enums/user.enum";
 import mockAlertData from "constants/mock/alerts.json";
-import useToast from "hooks/useToast";
 import useResponsiveHeader from "hooks/useResponsiveNavbar";
 import styles from "./GlobalNav.module.scss";
 
@@ -23,8 +20,6 @@ const ALERT_LIST: IAlert[] = mockAlertData.items.map((i) => {
 
 const GlobalNav = () => {
   const user = useAppSelector((state) => { return state.user; });
-  const { showToast } = useToast();
-  const dispatch = useAppDispatch();
   const router = useRouter();
   const [alertList, setAlertList] = useState<IAlert[]>([]);
   const navRef = useRef(null);
@@ -41,9 +36,7 @@ const GlobalNav = () => {
   };
 
   const handleSignOut = () => {
-    dispatch(setUser({ token: undefined, userInfo: undefined }));
-    showToast("로그아웃 되었습니다.");
-    router.push("/");
+    router.push("/signout");
   };
 
   return (

--- a/components/hocs/index.ts
+++ b/components/hocs/index.ts
@@ -1,0 +1,6 @@
+import withAuth from "./withAuth/withAuth";
+import withUserType from "./withUserType/withUserType";
+
+export {
+  withAuth, withUserType,
+};

--- a/components/hocs/indext.ts
+++ b/components/hocs/indext.ts
@@ -1,5 +1,0 @@
-import withAuth from "./withAuth/withAuth";
-
-export {
-  withAuth,
-};

--- a/components/hocs/indext.ts
+++ b/components/hocs/indext.ts
@@ -1,0 +1,5 @@
+import withAuth from "./withAuth/withAuth";
+
+export {
+  withAuth,
+};

--- a/components/hocs/withAuth/withAuth.tsx
+++ b/components/hocs/withAuth/withAuth.tsx
@@ -1,0 +1,28 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { ComponentType, useEffect, useState } from "react";
+import { redirect } from "next/navigation";
+import useAppSelector from "redux/hooks/useAppSelector";
+import useErrorModal from "hooks/useErrorModal";
+
+const withAuth = (Component: ComponentType) => {
+  const WithAuthHOC = <P extends object>(props: P) => {
+    const user = useAppSelector((state) => { return state.user; });
+    const { showErrorModal } = useErrorModal();
+    const [isAuthorized, setIsAuthorized] = useState(false);
+
+    useEffect(() => {
+      if (!user.token) {
+        showErrorModal("로그인이 필요합니다.");
+        redirect("/auth?mode=signin");
+      }
+      setIsAuthorized(true);
+    }, [showErrorModal, user.token]);
+    if (!isAuthorized) return null;
+    return (
+      <Component {...props} />
+    );
+  };
+  return WithAuthHOC;
+};
+
+export default withAuth;

--- a/components/hocs/withUserType/withUserType.tsx
+++ b/components/hocs/withUserType/withUserType.tsx
@@ -3,27 +3,27 @@ import { ComponentType, useEffect, useState } from "react";
 import { redirect } from "next/navigation";
 import useAppSelector from "redux/hooks/useAppSelector";
 import useErrorModal from "hooks/useErrorModal";
+import { UserType } from "types/enums/user.enum";
 
-const withAuth = (Component: ComponentType) => {
-  const WithAuthHOC = <P extends object>(props: P) => {
+const withUserType = (Component: ComponentType, userType: UserType) => {
+  const WithUserTypeHOC = <P extends object>(props: P) => {
     const user = useAppSelector((state) => { return state.user; });
     const { showErrorModal } = useErrorModal();
     const [isAuthorized, setIsAuthorized] = useState(false);
-
     useEffect(() => {
-      if (!user.token) {
-        showErrorModal("로그인이 필요합니다.");
-        setIsAuthorized(false);
-        redirect("/auth?mode=signin");
+      if (!user.userInfo) return;
+      if (user.userInfo.type !== userType) {
+        showErrorModal("권한이 없습니다.");
+        redirect("/");
       }
       setIsAuthorized(true);
-    }, []);
+    }, [showErrorModal, user.userInfo]);
     if (!isAuthorized) return null;
     return (
       <Component {...props} />
     );
   };
-  return WithAuthHOC;
+  return WithUserTypeHOC;
 };
 
-export default withAuth;
+export default withUserType;

--- a/components/notice/RecommendedNoticeList/RecommendedNoticeList.tsx
+++ b/components/notice/RecommendedNoticeList/RecommendedNoticeList.tsx
@@ -34,7 +34,7 @@ const RecommendedNoticeList = () => {
         <Spinner />
       </div>
     );
-  } if (!noticeList) {
+  } if (!noticeList?.items.length) {
     return (<div className={styles.loadingContainer}>회원님을 위한 맞춤공고가 없어요</div>);
   }
   return (

--- a/hooks/api/image/usePostImageName.ts
+++ b/hooks/api/image/usePostImageName.ts
@@ -1,0 +1,30 @@
+/* eslint-disable consistent-return */
+import { usePostImageNameMutation } from "redux/api/imageApi";
+import useErrorModal from "hooks/useErrorModal";
+import { isFetchBaseQueryError } from "utils/predicateErrorType";
+
+const usePostImageName = () => {
+  const [sendRequest, { isLoading, isError }] = usePostImageNameMutation();
+  const { showErrorModal } = useErrorModal();
+
+  const postImageName = async (
+    body: { name: string },
+  ) => {
+    try {
+      const data = await sendRequest(body).unwrap();
+      return data;
+    } catch (err) {
+      if (isFetchBaseQueryError(err)) {
+        const errorObj = "error" in err ? err.error : err.data as { message: string };
+        if (typeof errorObj !== "string") {
+          showErrorModal(errorObj.message);
+        }
+      }
+      console.error(err);
+    }
+  };
+
+  return { postImageName, isLoading, isError };
+};
+
+export default usePostImageName;

--- a/hooks/api/user/useLazyGetUserInfo.ts
+++ b/hooks/api/user/useLazyGetUserInfo.ts
@@ -1,0 +1,17 @@
+import { userApi } from "redux/api/userApi";
+
+const useLazyGetUserInfo = () => {
+  const [trigger, {
+    isLoading: isUserInfoLoading, data: userInfoData, isSuccess: isUserInfoFetched,
+  }] = userApi.endpoints.getUserInfo.useLazyQuery();
+
+  const getUserInfo = async (userId: string) => {
+    await trigger(userId);
+  };
+
+  return {
+    getUserInfo, isUserInfoLoading, userInfoData, isUserInfoFetched,
+  };
+};
+
+export default useLazyGetUserInfo;

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,30 +1,17 @@
-import { useEffect } from "react";
 import useAppDispatch from "redux/hooks/useAppDispatch";
-import useAppSelector from "redux/hooks/useAppSelector";
 import { setShow, setToastMessage } from "redux/slices/toastSlice";
 
 const useToast = () => {
-  const isShowing = useAppSelector((state) => { return state.toast.isShowing; });
   const dispatch = useAppDispatch();
 
   const showToast = (message: string) => {
     dispatch(setToastMessage(message));
     dispatch(setShow(true));
+
+    setTimeout(() => {
+      dispatch(setShow(false));
+    }, 3000);
   };
-
-  useEffect(() => {
-    let timer: NodeJS.Timeout;
-
-    if (isShowing) {
-      timer = setTimeout(() => {
-        dispatch(setShow(false));
-      }, 3000);
-    }
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [dispatch, isShowing]);
 
   return { showToast };
 };

--- a/redux/api/imageApi.ts
+++ b/redux/api/imageApi.ts
@@ -1,0 +1,27 @@
+import { apiSlice } from "redux/slices/apiSlice";
+import { ILink } from "types/dto";
+
+interface IPostImageNameResponse {
+  item: {
+    url: string,
+  },
+  links: ILink[];
+}
+
+export const imageApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => {
+    return {
+      postImageName: builder.mutation<IPostImageNameResponse, { name: string }>({
+        query: (body) => {
+          return {
+            url: "images",
+            method: "POST",
+            body,
+          };
+        },
+      }),
+    };
+  },
+});
+
+export const { usePostImageNameMutation } = imageApi;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
- withAuth, withUserType HOC를 추가했습니다.
- 로그인이 필요한 페이지 컴포넌트를 withAuth로 감싸서 내보내기 하면 됩니다. 참고로 withAuth는 로그인 여부 판단하기 때문에 페이지를 감쌀 시 use client를 써야 합니다. 
- 사장님만 접근 가능한 페이지, 예를 들면 /my-shop 등의 페이지는 withUserType으로 감싸서 내보내기 하면 됩니다. 물론 로그인이 선행되어야 하므로 withAuth로 이중으로 감싸면 됩니다. 
- 에시) 
```tsx
export default withAuth(withUserType(MyshopPage, UserType.EMPLOYER));

export default withAuth(withUserType(MyProfileEditPage, UserType.EMPLOYEE));
```

- useToast관련 버그 발견해서 수정했습니다.
- 로그아웃을 내브바에서 다이렉트로 수행하던 것을 중간 signout processing 페이지를 두어 다른 라우트에서 수행하게 했습니다. withAuth를 unmount한 뒤 유저 정보를 삭제해야 중간에 withAuth에 등록되어있는 useEffect가 발동하지 않기때문에 그렇게 처리 해줬습니다 

## 확인 방법
<!-- 변경 사항을 검토하고 테스트하기 위한 방법을 설명하거나 이미지를 첨부해 주세요. -->
- 위 설명을 읽고 잘 쓰시길 바랍니다. 이미 있는 페이지들에는 이미 적용시켰습니다. 

## 기타 사항
<!-- 기타 참고할 사항이 있다면 적어주세요 -->
