### PR TITLE
JUL-113/로그인 로딩 컴포넌트 추가

### DIFF
--- a/app/signout/page.tsx
+++ b/app/signout/page.tsx
@@ -1,31 +1,46 @@
 "use client";
 
-import { withAuth } from "components/hocs";
 import useToast from "hooks/useToast";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import useAppDispatch from "redux/hooks/useAppDispatch";
+import useAppSelector from "redux/hooks/useAppSelector";
 import { setUser } from "redux/slices/userSlice";
 
 const SignoutPage = () => {
   const dispatch = useAppDispatch();
+  const [isChecked, setIsChecked] = useState(false);
   const [isLoggedOut, setIsLoggedOut] = useState(false);
   const router = useRouter();
   const { showToast } = useToast();
 
-  useEffect(() => {
-    dispatch(setUser({ token: undefined, userInfo: undefined }));
-    setIsLoggedOut(true);
-  }, [dispatch]);
+  const user = useAppSelector((state) => { return state.user; });
+
+  useLayoutEffect(() => {
+    if (!user.token) {
+      setIsChecked(false);
+      router.push("/");
+    } else {
+      setIsChecked(true);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router]);
 
   useEffect(() => {
-    if (isLoggedOut) {
+    if (isChecked) {
+      dispatch(setUser({ token: undefined, userInfo: undefined }));
+      setIsLoggedOut(true);
+    }
+  }, [dispatch, isChecked]);
+
+  useEffect(() => {
+    if (isLoggedOut && isChecked) {
       showToast("로그아웃 되었습니다.");
       router.push("/");
     }
-  }, [isLoggedOut, showToast, router]);
+  }, [isLoggedOut, showToast, router, isChecked]);
 
   return null;
 };
 
-export default withAuth(SignoutPage);
+export default SignoutPage;

--- a/components/auth/AuthForm/SigninForm.tsx
+++ b/components/auth/AuthForm/SigninForm.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useState } from "react";
 import { setUser } from "redux/slices/userSlice";
 import useAppDispatch from "redux/hooks/useAppDispatch";
 import { CustomInput, Loader } from "components/common";
+import SigninProcess from "components/auth/SigninProcess/SigninProcess";
 import { ValidationTarget } from "types/enums/inputValidation.enum";
 import useSignin from "hooks/api/auth/useSignin";
 import inputValidation from "utils/inputValidation";
@@ -17,7 +18,7 @@ const SigninForm = () => {
   const [rendering, setRendering] = useState(false);
   const { signin, isLoading } = useSignin();
   const {
-    getUserInfo, userInfoData, isUserInfoLoading,
+    getUserInfo, userInfoData, isUserInfoLoading, isUserInfoFetching,
   } = useLazyGetUserInfo();
   const [countValidation, setCountValidation] = useState({
     email: 0,
@@ -40,7 +41,7 @@ const SigninForm = () => {
     });
   };
 
-  const setUserState = async (token: string, userId: string) => {
+  const setUserState = async (userId: string) => {
     await getUserInfo(userId);
   };
 
@@ -60,7 +61,7 @@ const SigninForm = () => {
       if (res) {
         const { item: { token, user: { item: { id } } } } = res;
         dispatch(setUser({ ...user, token }));
-        await setUserState(token, id as string);
+        await setUserState(id as string);
       }
     }
   };
@@ -72,6 +73,9 @@ const SigninForm = () => {
     }
   }, [userInfoData, user, dispatch]);
 
+  if ((isLoading || isUserInfoLoading) || isUserInfoFetching || isUserInfoLoading) {
+    return <SigninProcess isSigningIn={isLoading} isFetchingUserInfo={isUserInfoFetching} />;
+  }
   return (
     <form
       className={styles.form}

--- a/components/auth/SigninProcess/SigninProcess.module.scss
+++ b/components/auth/SigninProcess/SigninProcess.module.scss
@@ -6,11 +6,10 @@
 	gap: 2rem;
 	.loadingAnimation {
 		.loader {
-	
 			display: flex;
 			align-items: center;
 			justify-content: center;
-		}   
+		} 
 
 		.car {
 			&__body {
@@ -22,12 +21,15 @@
 				stroke-dasharray: 22;
 				animation: line 0.8s ease-in-out infinite;
 				animation-fill-mode: both;
+
 				&--top {
 					animation-delay: 0s;
 				}
+
 				&--middle {
 					animation-delay: 0.2s;
 				}
+
 				&--bottom {
 					animation-delay: 0.4s;
 				}
@@ -75,13 +77,22 @@
 		animation: dotty steps(1,end) 1s infinite;
 		content: '';
 	}
-	
 }
 
 @keyframes dotty {
-		0%   { content: ''; }
-		25%  { content: '.'; }
-		50%  { content: '..'; }
-		75%  { content: '...'; }
-		100% { content: ''; }
+	0% {
+		content: '';
+	}
+	25% {
+		content: '.'; 
+	}
+	50% {
+		content: '..';
+	}
+	75% {
+		content: '...';
+	}
+	100% {
+		content: '';
+	}
 }

--- a/components/auth/SigninProcess/SigninProcess.module.scss
+++ b/components/auth/SigninProcess/SigninProcess.module.scss
@@ -1,0 +1,87 @@
+.container {
+	@include fixed(0,0,0,0);
+	background-color: $red-40;
+	z-index: 9999;
+	@include flexbox(column, center, center);
+	gap: 2rem;
+	.loadingAnimation {
+		.loader {
+	
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}   
+
+		.car {
+			&__body {
+				animation: shake 0.2s ease-in-out infinite alternate;
+			}
+			
+			&__line {
+				transform-origin: center right;
+				stroke-dasharray: 22;
+				animation: line 0.8s ease-in-out infinite;
+				animation-fill-mode: both;
+				&--top {
+					animation-delay: 0s;
+				}
+				&--middle {
+					animation-delay: 0.2s;
+				}
+				&--bottom {
+					animation-delay: 0.4s;
+				}
+			}
+		}
+		
+		@keyframes shake {
+			0% {
+				transform: translateY(-1%);
+			}
+			100% {
+				transform: translateY(3%);
+			}
+		}
+		
+		@keyframes line {
+			0% {
+				stroke-dashoffset: 22;
+			}	
+			25% {
+				stroke-dashoffset: 22;
+			}
+			50% {
+				stroke-dashoffset: 0;
+			}
+			51% {
+				stroke-dashoffset: 0;
+			}
+			80% {
+				stroke-dashoffset: -22;
+			}
+			100% {
+				stroke-dashoffset: -22;
+			}
+		}
+	}
+
+	.loadingText {
+		color: $white;
+		font-size: 2rem;
+	}
+	.loadingText::after {
+		position: absolute;
+		display: inline-block;
+		animation: dotty steps(1,end) 1s infinite;
+		content: '';
+	}
+	
+}
+
+@keyframes dotty {
+		0%   { content: ''; }
+		25%  { content: '.'; }
+		50%  { content: '..'; }
+		75%  { content: '...'; }
+		100% { content: ''; }
+}

--- a/components/auth/SigninProcess/SigninProcess.tsx
+++ b/components/auth/SigninProcess/SigninProcess.tsx
@@ -1,0 +1,36 @@
+import classNames from "classnames/bind";
+import styles from "./SigninProcess.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface SigninProcessProps {
+  isSigningIn: boolean;
+  isFetchingUserInfo: boolean;
+}
+
+const SigninProcess = ({ isSigningIn, isFetchingUserInfo }: SigninProcessProps) => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.loadingAnimation}>
+        <div className={styles.loader}>
+          <svg className={styles.car} width="102" height="40" xmlns="http://www.w3.org/2000/svg">
+            <g transform="translate(2 1)" stroke="#FFF" fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round">
+              <path className={cx("car__body")} d="M47.293 2.375C52.927.792 54.017.805 54.017.805c2.613-.445 6.838-.337 9.42.237l8.381 1.863c2.59.576 6.164 2.606 7.98 4.531l6.348 6.732 6.245 1.877c3.098.508 5.609 3.431 5.609 6.507v4.206c0 .29-2.536 4.189-5.687 4.189H36.808c-2.655 0-4.34-2.1-3.688-4.67 0 0 3.71-19.944 14.173-23.902zM36.5 15.5h54.01" strokeWidth="3" />
+              <ellipse className={cx("car__wheel--left")} strokeWidth="3.2" fill="#FFF" cx="83.493" cy="30.25" rx="6.922" ry="6.808" />
+              <ellipse className={cx("car__wheel--right")} strokeWidth="3.2" fill="#FFF" cx="46.511" cy="30.25" rx="6.922" ry="6.808" />
+              <path className={cx("car__line", "car__line--top")} d="M22.5 16.5H2.475" strokeWidth="3" />
+              <path className={cx("car__line", "car__line--middle")} d="M20.5 23.5H.4755" strokeWidth="3" />
+              <path className={cx("car__line", "car__line--bottom")} d="M25.5 9.5h-19" strokeWidth="3" />
+            </g>
+          </svg>
+        </div>
+      </div>
+      <h2 className={styles.loadingText}>
+        {(isSigningIn && !isFetchingUserInfo) && "로그인 중이에요"}
+        {(!isSigningIn && isFetchingUserInfo) && "회원 정보를 불러오는 중이에요"}
+      </h2>
+    </div>
+  );
+};
+
+export default SigninProcess;

--- a/hooks/api/user/useLazyGetUserInfo.ts
+++ b/hooks/api/user/useLazyGetUserInfo.ts
@@ -2,7 +2,10 @@ import { userApi } from "redux/api/userApi";
 
 const useLazyGetUserInfo = () => {
   const [trigger, {
-    isLoading: isUserInfoLoading, data: userInfoData, isSuccess: isUserInfoFetched,
+    isLoading: isUserInfoLoading,
+    data: userInfoData,
+    isSuccess: isUserInfoFetched,
+    isFetching: isUserInfoFetching,
   }] = userApi.endpoints.getUserInfo.useLazyQuery();
 
   const getUserInfo = async (userId: string) => {
@@ -10,7 +13,7 @@ const useLazyGetUserInfo = () => {
   };
 
   return {
-    getUserInfo, isUserInfoLoading, userInfoData, isUserInfoFetched,
+    getUserInfo, isUserInfoLoading, userInfoData, isUserInfoFetched, isUserInfoFetching,
   };
 };
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
- 로그인을 시도할 때, 로그인에 성공하면 회원 정보를 추가로 불러오는 요청때문에 로딩이 길어져서 동적인 애니메이션과 로딩 문구를 추가했습니다.
- 로그아웃을 중간 프로세싱 페이지를 추가한 것처럼 로그인도 중간 프로세싱 페이지를 만들려고 했으나, 페이지간 로그인 데이터 전송방법이 쿼리 파라미터 뿐인데 아이디 비밀번호가 url에 노출되는 문제가 있어 그냥 화면 전체를 덮는 프로세싱 컴포넌트를 조건부 렌더링 처리 했습니다.

## 확인 방법
![로그인프로세스](https://github.com/LonelyIslet/TheJulge/assets/45449387/2a00c35c-d93a-4268-95e3-daa9af0b5f0b)


## 기타 사항
<!-- 기타 참고할 사항이 있다면 적어주세요 -->
