### PR TITLE
JUL-114/맞춤공고 없을 때 보여질 디폴트 UI 및 공고카드 툴팁 기능 추가 

### DIFF
--- a/components/common/PostCard/PostCard.module.scss
+++ b/components/common/PostCard/PostCard.module.scss
@@ -140,6 +140,7 @@
       justify-content: space-between;
       align-items: center;
       gap: 0.5rem;
+      position: relative;
 
       .hourlyPay {
         font-size: 2.4rem;

--- a/components/common/PostCard/PostCard.tsx
+++ b/components/common/PostCard/PostCard.tsx
@@ -1,6 +1,10 @@
+"use client";
+
+import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import classNames from "classnames/bind";
+import Tooltip from "components/common/Tooltip/Tooltip";
 import calculatePercentage from "utils/calculatePercentage";
 import formatTimeRange from "utils/formatTimeRange";
 import getBgColorClass from "utils/getBgColorClass";
@@ -32,6 +36,7 @@ const PostCard = ({
   originalHourlyPay,
   href,
 }: PostCardProps) => {
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const isPassed = new Date() > new Date(startsAt);
   const isClosed = closed || isPassed;
   const percentage = calculatePercentage(hourlyPay, originalHourlyPay);
@@ -84,10 +89,15 @@ const PostCard = ({
           </div>
         </div>
         <div className={styles.hourlyPayContainer}>
-          <p className={cx("hourlyPay", { isClosed })}>
+          <p
+            className={cx("hourlyPay", { isClosed })}
+            onMouseEnter={() => { setIsTooltipVisible(true); }}
+            onMouseLeave={() => { setIsTooltipVisible(false); }}
+          >
             {hourlyPay.toLocaleString()}
             원
           </p>
+          <Tooltip isVisible={isTooltipVisible} message={`${hourlyPay.toLocaleString()}원`} />
           {percentage >= 5
             && (
               <div className={cx("payPercentage", { isClosed }, `${bgColorClass}`)}>

--- a/components/common/Tooltip/Tooltip.module.scss
+++ b/components/common/Tooltip/Tooltip.module.scss
@@ -1,0 +1,24 @@
+.container {
+	position: absolute;
+	top: 1rem;
+	background-color: rgba(0,0,0,0.8);
+	margin: 1.6rem auto;
+	visibility: visible;
+	color: $white;
+	width: fit-content;
+	padding: 10px;
+	border-radius: 4px;
+	font-size: 1.8rem;
+	text-align: center;
+	line-height: 1.25rem;
+	letter-spacing: -0.02rem;
+	white-space: pre-line;
+	z-index: 100;
+	transition: visibility 0.5s, color 0.5s, background-color 0.5s, width 0.5s,
+	padding 0.5s ease-in-out;
+
+	&.hidden {
+		visibility: hidden;
+		background-color: transparent;
+	}
+}

--- a/components/common/Tooltip/Tooltip.module.scss
+++ b/components/common/Tooltip/Tooltip.module.scss
@@ -6,13 +6,10 @@
 	visibility: visible;
 	color: $white;
 	width: fit-content;
-	padding: 10px;
-	border-radius: 4px;
+	padding: 1rem;
+	border-radius: 0.4rem;
 	font-size: 1.8rem;
 	text-align: center;
-	line-height: 1.25rem;
-	letter-spacing: -0.02rem;
-	white-space: pre-line;
 	z-index: 100;
 	transition: visibility 0.5s, color 0.5s, background-color 0.5s, width 0.5s,
 	padding 0.5s ease-in-out;

--- a/components/common/Tooltip/Tooltip.tsx
+++ b/components/common/Tooltip/Tooltip.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import classNames from "classnames/bind";
+import styles from "./Tooltip.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface TooltipProps {
+  isVisible: boolean;
+  message: string;
+}
+
+const Tooltip = ({ isVisible, message }: TooltipProps) => {
+  return (
+    <div className={cx("container", !isVisible && "hidden")}>
+      {message}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/components/notice/RecommendedNoticeList/DefaultRecommendedList.module.scss
+++ b/components/notice/RecommendedNoticeList/DefaultRecommendedList.module.scss
@@ -1,0 +1,32 @@
+.container {
+	margin: 0 auto;
+	width: 100%;
+	height: 38rem;
+	border-radius: 1.2rem;
+	border: 1px solid $gray-30;
+	@include flexbox(column, center, center);
+	gap: 3rem;
+	@include mobile {
+		height: 30rem;
+	}
+	& > * {
+		width: 80%;
+	}
+	h2 {
+		font-size: 2.2rem;
+
+		span {
+			color: $primary;
+		}
+	}
+
+	.tooltipHeader {
+		color: $red-40;
+		font-size: 1.8rem;
+	}
+	.tooltipContent {
+		span {
+			color: $red-40;
+		}
+	}
+}

--- a/components/notice/RecommendedNoticeList/DefaultRecommendedList.tsx
+++ b/components/notice/RecommendedNoticeList/DefaultRecommendedList.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import useAppSelector from "redux/hooks/useAppSelector";
+import { CommonBtn } from "components/common";
+import Link from "next/link";
+import styles from "./DefaultRecommendedList.module.scss";
+
+const DefaultRecommendedList = () => {
+  const userName = useAppSelector((state) => { return state.user?.userInfo?.name ?? "회원"; });
+  return (
+    <div className={styles.container}>
+      <h2>
+        <span>{userName}</span>
+        님을 위한 맞춤공고가 없어요☹️
+      </h2>
+      <h3 className={styles.tooltipHeader}>
+        *맞춤 공고란?
+      </h3>
+      <p className={styles.tooltipContent}>
+        설정된 선호 지역을 기반으로
+        {" "}
+        <span>더줄게</span>
+        에서 추천하는 공고입니다.
+        <br />
+        프로필 페이지에서 선호지역을 설정 또는 수정하고 가까운 가게의 공고를 추천받아 보세요!
+      </p>
+      <Link href="/my-profile/edit">
+        <CommonBtn>프로필 편집하러 가기</CommonBtn>
+      </Link>
+    </div>
+  );
+};
+
+export default DefaultRecommendedList;

--- a/components/notice/RecommendedNoticeList/RecommendedNoticeList.module.scss
+++ b/components/notice/RecommendedNoticeList/RecommendedNoticeList.module.scss
@@ -6,4 +6,6 @@
 	@include mobile {
 		height: 30rem;
 	}
+
+
 }

--- a/components/notice/RecommendedNoticeList/RecommendedNoticeList.tsx
+++ b/components/notice/RecommendedNoticeList/RecommendedNoticeList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { PostCard, Spinner, InfiniteCarousel } from "components/common";
+import DefaultRecommendedList from "components/notice/RecommendedNoticeList/DefaultRecommendedList";
 import useAppSelector from "redux/hooks/useAppSelector";
 import { SortOption, useGetNoticesQuery } from "redux/api/noticeApi";
 import useMediaQuery from "hooks/useMediaQuery";
@@ -39,7 +40,7 @@ const RecommendedNoticeList = () => {
   }
 
   if (!noticeList?.items.length) {
-    return (<div className={styles.loadingContainer}>회원님을 위한 맞춤공고가 없어요</div>);
+    return <DefaultRecommendedList />;
   }
 
   return (


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
- 맞춤 공고가 없는 경우(알바 회원이고, 선호 지역을 설정하지 않았을 때 OR 알바 회원이고, 선호 지역에 해당하는 공고가 하나도 없을 때)
- 맞춤 공고가 없으면 선호지역 설정 또는 수정을 권유(?)하는 문구와 프로필 편집 페이지로 가는 링크(버튼)를 띄웁니다. 
- 공고 카드에 일관된 크기를 유지하기 위해 가격 정보가 ellipsis처리되어 있는데, 총 시금이 얼마인지 카드만으로 식별이 불가한 문제가 있었습니다. 이를 위해 가격 부분을 호버시 툴팁 형태로 풀 가격이 나타나게 처리했습니다.

## 확인 방법
<img width="1332" alt="image" src="https://github.com/LonelyIslet/TheJulge/assets/45449387/fc04f391-7495-4964-85cb-7ced773d6a01">

<img width="506" alt="image" src="https://github.com/LonelyIslet/TheJulge/assets/45449387/433112cc-3849-49a8-a95d-a2eb62467bfb">


## 기타 사항
<!-- 기타 참고할 사항이 있다면 적어주세요 -->
